### PR TITLE
fix: check for duplicate concept ID error

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,39 @@
+package ocl
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// APIErrorResponse represents the structure that an error message will be returned with.
+type APIErrorResponse struct {
+	All []string `json:"__all__"`
+}
+
+// APIError represents a structured API error response.
+type APIError struct {
+	StatusCode int
+	RawBody    string
+	APIError   APIErrorResponse
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API request failed (HTTP %d): %s", e.StatusCode, e.RawBody)
+}
+
+// IsDuplicateConceptIDError checks if an error is due to a duplicate Concept ID within a source.
+func IsDuplicateConceptIDError(err error) bool {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		if apiErr.StatusCode == http.StatusBadRequest {
+			for _, msg := range apiErr.APIError.All {
+				if msg == "Concept ID must be unique within a source." {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/http.go
+++ b/http.go
@@ -108,7 +108,18 @@ func (c *Client) makeRequest(
 			return err
 		}
 
-		return fmt.Errorf("failed (HTTP %d): %s", resp.StatusCode, string(body))
+		apiErr := APIErrorResponse{}
+
+		err = json.Unmarshal(body, &apiErr)
+		if err != nil {
+			return fmt.Errorf("failed (HTTP %d): %s", resp.StatusCode, string(body))
+		}
+
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			RawBody:    string(body),
+			APIError:   apiErr,
+		}
 	}
 
 	if result != nil {


### PR DESCRIPTION
- The Openconceptlab API typically returns such an error when a concept ID is found to exits
```
{
    "__all__": [
        "Concept ID must be unique within a source."
    ]
}
```
In our workflows though, we check for this error as a sort of guardrail