### PR TITLE
fix: remove timeout option

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,10 +7,6 @@ import (
 	"time"
 )
 
-const (
-	defaultTimeout = 10 * time.Second
-)
-
 type Client struct {
 	baseURL string
 	token   string
@@ -44,9 +40,7 @@ func NewClient(baseURL string, token string, options ...ClientOption) (*Client, 
 	}
 
 	client := &Client{
-		HTTP: &http.Client{
-			Timeout: defaultTimeout,
-		},
+		HTTP:    &http.Client{},
 		baseURL: baseURL,
 		token:   token,
 	}


### PR DESCRIPTION
- The client implementer will be responsible for setting this up using the `WithTimeout` method. But default config is that there is no timeout